### PR TITLE
Addons configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Engine.jar
 .project
 .env
 src/main/config
+src/renderer/.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Also support of many fan-expansions, chat during game, lobby.
 All issues on FanCloisterZone report on [Discord](https://discord.gg/CswNeVg3eS)
 
 ## Supported Fan Expansions
+
 * [Black Tower](https://wikicarpedia.com/car/Black_Tower_(Fan_Expansion))
 * [City Gates, The](https://wikicarpedia.com/car/The_City_Gates_(1st_edition))
 * [Decinsky Sneznik](https://wikicarpedia.com/car/D%C4%9B%C4%8D%C3%ADnsk%C3%BD_Sn%C4%9B%C5%BEn%C3%ADk_(Fan_Expansion))
@@ -20,20 +21,21 @@ All issues on FanCloisterZone report on [Discord](https://discord.gg/CswNeVg3eS)
 * [Wells, The](https://wikicarpedia.com/car/The_Wells_(Fan_Expansion))
 
 ### Upcomming
+
 * The Courier
 * The Carousel
 * Castle Lords
 
 ## Engine
 
-Engine for game can be found on https://github.com/fancarpedia/JCloisterZoneEngine
-
+Engine for game can be found on [JCloisterZoneEngine](https://github.com/fancarpedia/JCloisterZoneEngine)
 
 ## I want to help
 
 There is several options how you halp help this open-source project. You can ask on our [Discord](https://discord.gg/3qpHWN8k)
 
 ### How I can help
+
 * Better UI
 * Better AI/Bot answers / quicker response
 * Creating addons for new fan expansions - tile shapes and/or game mechanics
@@ -71,26 +73,29 @@ Another option is running against dev version of engine.
 Run engine listening to socket. It will be usualy started using Java IDE.
 Add program args to run configuration
 
-```
+```sh
 java -Dorg.slf4j.simpleLogger.log.AIRanking=debug -ea -jar build\Engine.jar -port 9001
 ```
 
 Add engine's socket address to jcz-config.json (you can find location in Main menu / Help / About)
-```
+
+```sh
 "enginePath": "localhost:9001",
 ```
 
 ### Run second client with different config in dev
 
-```
+```sh
 JCZ_CONFIG=/home/user/.config/Electron/jcz-config-2.json JCZ_NETWORK_DELAY=1-50 yarn dev
 ```
 
 ## Special downgrades
+
 Envoronment requires node 16, yarn 1, java 17
 
 ### On Mac
-```
+
+```sh
 corepack disable
 npm uninstall -g yarn
 npm install -g yarn@1
@@ -99,17 +104,22 @@ yarn --version
 ```
 
 ### Every Operating Systems
+
 Check if version is 1.22.x
-```
+
+```sh
 nvm install 16
 nvm use 16
 node --version
 ```
-Check if version is 16.x.x 
+
+Check if version is 16.x.x
 
 ### Update package.json (macOS)
+
 Add package manager witch current yarn version
-```
+
+```json
   "packageManager": "yarn@1.22.22"
 ```
 
@@ -123,13 +133,15 @@ Add package manager witch current yarn version
 `src/renderer/assets/styles/themes.scss`
 
 * Use that value in Vue component
-```
+
+```js
 element
   +theme using ($theme)
   css-property: map-get($theme, 'new-value-key')
-``` 
+```
 
 #### Use theme in Vue compoments
+
 `const theme = this.$vuetify.theme.dark ? 'dark' : 'light'`
 
 ### Add new language
@@ -150,7 +162,9 @@ element
 `src/renferer/nuxt.config.js`
 
 ### Use translated texts in Vue
+
 #### Usage in `<template>`
+
 As parameter: `:parameter="$t('about.fantitle')"`
 
 As text: `{{ $t('about.fantitle') }}`
@@ -162,28 +176,34 @@ As text: `{{ $t('about.fantitle') }}`
 $nuxt.$t('index.local.saved-game')
 
 ### Mark texts for translation
+
 `<!-- TRANSLATE -->`
 
 ### Add package failed with Webpack 4 or Node 16 (by use babe this.config?.something or this.value ?? failvervalue
 
 * Append file to `babelRequiredFiles` in `src/renderer/nuxt.config.js` as example for `megajs`
-  ```
+
+  ```js
   const babelRequiredPaths = [
     path.resolve(require.resolve('megajs'), '..', '..')
   ]
   ```
-### Prepare build 
+
+### Prepare build
 
 #### Load all locales
+
   `yarn locale-updates`
 
 #### Try to build to test installation
+
   `yarn build`
 
 #### Update package.json for current app version
 
 #### Github stuff for create a release
-  ```
+  
+  ```sh
   git push
   git tag -a RELEASE
   git push origin RELEASE

--- a/docs/ADDON_MANAGEMENT.md
+++ b/docs/ADDON_MANAGEMENT.md
@@ -1,0 +1,100 @@
+# Add-on Management
+
+Addon management uses a manifest-driven flow with a single reload path for startup, manual changes, installs, uninstalls, and automatic updates.
+
+## Startup Flow
+
+1. The main process registers a small IPC endpoint that returns the built-in add-on defaults, including the fallback manifest URL.
+2. The renderer reads the current `addonsManifestUrl` setting.
+3. If the setting is empty, the renderer uses the built-in default manifest URL.
+4. The add-on service fetches the manifest, filters versions to those compatible with the current app version, and builds the downloadable list.
+5. Installed add-ons are loaded from disk and merged into one in-memory list.
+6. After the first load, the app checks whether any downloadable add-on is outdated and updates it if auto-update is allowed.
+
+## Installed Add-ons
+
+Installed add-ons are collected from:
+
+- `settings.userAddons`, which are custom folders chosen by the user.
+- `process.resourcesPath/addons`, which contains bundled add-ons.
+- The user data add-ons directory, which is where downloaded add-ons are installed.
+
+The loader keeps the first add-on with a given id and ignores later duplicates. That means a user-provided add-on can override a bundled one with the same id.
+
+Each add-on is validated before it is accepted:
+
+- `jcz-addon.json` must exist.
+- `version` must be a valid integer.
+- `minimumJczVersion` must be present.
+- The add-on must be compatible with the running app version.
+
+If the add-on defines artwork entries, those artworks are loaded after the add-on metadata is accepted. When an add-on is installed or removed, its artwork ids are added to or removed from the enabled artwork list in settings.
+
+## Downloadable Add-ons
+
+The downloadable list is built from the manifest JSON.
+
+- Each add-on entry may contain several versions.
+- Only versions compatible with the current app version are kept.
+- Development builds use the dev-specific version bounds when they are present.
+- The classic add-on must be present in the manifest and must include a `sha256` checksum.
+
+When the user installs a downloadable add-on, the app:
+
+1. Resolves the download URL, including trying multiple mirrors when needed.
+2. Downloads the `.jca` package to a temporary file.
+3. Verifies the SHA-256 checksum when one is provided.
+4. Unpacks the archive into a temporary directory.
+5. Validates the extracted add-on metadata.
+6. Moves the add-on into the user data add-ons folder.
+
+If the add-on is already installed and the requested version is newer, the old version is removed first and then replaced.
+
+## Automatic Updates
+
+The update pass currently focuses on downloadable add-ons that allow auto-update.
+
+- On startup, the app checks installed add-ons against the manifest.
+- If a newer compatible version exists, the add-on is removed and reinstalled.
+- After an update, the app reloads add-ons, tiles, and artworks so the UI reflects the new files immediately.
+
+The classic add-on gets one extra check: if the installed copy is missing or outdated, the app can download the newest compatible version from the manifest and replace the old files.
+
+## Reload Behavior
+
+The app now refreshes add-ons when any of these happen:
+
+- The user changes the manifest URL.
+- The user edits the list of custom add-on folders.
+- An add-on is installed or uninstalled.
+- The developer menu action for reloading add-ons is used.
+
+This keeps the in-memory add-on list, the tile and artwork loaders, and the settings UI in sync.
+
+## Game Validation
+
+Saved games and remote games can declare required add-ons and versions.
+
+- If a required add-on is missing, the game is blocked.
+- If an installed add-on is older than the required version, the game is blocked.
+- The validation runs for both local saves and remote games, so a match cannot start with incompatible content.
+
+## User Experience
+
+In the Settings screen, the user can:
+
+- Leave the manifest URL empty to use the built-in default.
+- Paste a custom manifest URL.
+- Install a local `.jca` file by drag and drop or file picker.
+- Install downloadable add-ons from the manifest list.
+- Remove installed add-ons that are marked as removable.
+
+If the classic add-on is missing, the landing page shows a warning and displays the download URL that the app is currently using.
+
+## Main Files Involved
+
+- `src/main/modules/addonDefaults.js` provides the built-in manifest URL.
+- `src/renderer/plugins/addons.js` loads, validates, installs, updates, and removes add-ons.
+- `src/renderer/layouts/default.vue` triggers the initial reload and wires setting changes into the add-on service.
+- `src/renderer/components/settings/AddonsSettings.vue` exposes the add-on management UI.
+- `src/renderer/store/game.js` and `src/renderer/store/networking.js` block game loads when required add-ons are missing.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -16,6 +16,7 @@ import winevents from './modules/winevents'
 import settingsWatch from './modules/settingsWatch'
 import localServer from './modules/localServer'
 import installer from './modules/installer'
+import addonDefaults from './modules/addonDefaults'
 
 import RPC from 'discord-rpc'
 
@@ -152,6 +153,7 @@ app.whenReady().then(() => {
     const appVersion = getAppVersion()
     modules.push(updater(settings, appVersion))
     modules.push(installer())
+    addonDefaults()
 
     if (process.env.NODE_ENV === 'production') {
       modules.push(updater(settings))

--- a/src/main/modules/addonDefaults.js
+++ b/src/main/modules/addonDefaults.js
@@ -1,0 +1,9 @@
+import { ipcMain } from 'electron'
+
+const ADDON_DEFAULTS = {
+  addonsManifestUrl: 'https://github.com/fancarpedia/FanCloisterZone/releases/download/v6.0.0-all/addons.json'
+}
+
+export default function () {
+  ipcMain.handle('get-addon-defaults', () => ADDON_DEFAULTS)
+}

--- a/src/main/modules/menu.js
+++ b/src/main/modules/menu.js
@@ -11,6 +11,20 @@ async function createMenu (win, messages) {
   const settings = await getSettings()
 
   const isMac = process.platform === 'darwin'
+  const subMenuEdit = {
+    label: 'Edit',
+    submenu: [
+      { type: 'separator' },
+      { label: 'Cut', accelerator: 'Command+X', selector: 'cut:' },
+      { label: 'Copy', accelerator: 'Command+C', selector: 'copy:' },
+      { label: 'Paste', accelerator: 'Command+V', selector: 'paste:' },
+      {
+        label: 'Select All',
+        accelerator: 'Command+A',
+        selector: 'selectAll:'
+      }
+    ]
+  };
   const sessionSubmenu = [
     { id: 'new-game', label: $t('menu.new-game') || 'New Game', accelerator: 'CommandOrControl+N', click () { win.webContents.send('menu.new-game') } },
     { id: 'join-game', label: $t('menu.join-game') || 'Join Game', accelerator: 'CommandOrControl+J', click () { win.webContents.send('menu.join-game') } },
@@ -27,6 +41,10 @@ async function createMenu (win, messages) {
     {
       label: $t('menu.file') || 'File',
       submenu: sessionSubmenu
+    },
+    {
+      label: $t('menu.edit') || 'Edit',
+      submenu: subMenuEdit.submenu
     },
     {
       label: $t('menu.online') || 'Online',

--- a/src/main/modules/menu.js
+++ b/src/main/modules/menu.js
@@ -6,7 +6,7 @@ let _win
 let menu
 const enabledState = {}
 
-async function createMenu (win, messages) {
+async function createMenu(win, messages) {
   const $t = key => messages[key.replace('menu.', '')]
   const settings = await getSettings()
 
@@ -26,13 +26,13 @@ async function createMenu (win, messages) {
     ]
   };
   const sessionSubmenu = [
-    { id: 'new-game', label: $t('menu.new-game') || 'New Game', accelerator: 'CommandOrControl+N', click () { win.webContents.send('menu.new-game') } },
-    { id: 'join-game', label: $t('menu.join-game') || 'Join Game', accelerator: 'CommandOrControl+J', click () { win.webContents.send('menu.join-game') } },
+    { id: 'new-game', label: $t('menu.new-game') || 'New Game', accelerator: 'CommandOrControl+N', click() { win.webContents.send('menu.new-game') } },
+    { id: 'join-game', label: $t('menu.join-game') || 'Join Game', accelerator: 'CommandOrControl+J', click() { win.webContents.send('menu.join-game') } },
     { type: 'separator' },
-    { id: 'save-game', label: $t('menu.save-game') || 'Save Game', accelerator: 'CommandOrControl+S', click () { win.webContents.send('menu.save-game') } },
-    { id: 'load-game', label: [$t('menu.open-game') || 'Open Game', $t('menu.load-setup') || 'Load Setup'].join(' / '), accelerator: 'CommandOrControl+O', click () { win.webContents.send('menu.load-game') } },
+    { id: 'save-game', label: $t('menu.save-game') || 'Save Game', accelerator: 'CommandOrControl+S', click() { win.webContents.send('menu.save-game') } },
+    { id: 'load-game', label: [$t('menu.open-game') || 'Open Game', $t('menu.load-setup') || 'Load Setup'].join(' / '), accelerator: 'CommandOrControl+O', click() { win.webContents.send('menu.load-game') } },
     { type: 'separator' },
-    { id: 'settings', label: $t('menu.settings') || 'Settings', accelerator: 'CommandOrControl+,', click () { win.webContents.send('menu.show-settings') } },
+    { id: 'settings', label: $t('menu.settings') || 'Settings', accelerator: 'CommandOrControl+,', click() { win.webContents.send('menu.show-settings') } },
     { type: 'separator' },
     isMac ? { role: 'close', label: $t('menu.exit') } : { role: 'quit', label: $t('menu.exit') }
   ]
@@ -49,34 +49,34 @@ async function createMenu (win, messages) {
     {
       label: $t('menu.online') || 'Online',
       submenu: [
-        { id: 'playonline-connect', label: $t('menu.playonline-connect') || 'Play Online', accelerator: 'CommandOrControl+P', click () { win.webContents.send('menu.playonline-connect') } },
-        { id: 'playonline-disconnect', label: $t('menu.playonline-disconnect') || 'Disconnect', click () { win.webContents.send('menu.playonline-disconnect') } },
+        { id: 'playonline-connect', label: $t('menu.playonline-connect') || 'Play Online', accelerator: 'CommandOrControl+P', click() { win.webContents.send('menu.playonline-connect') } },
+        { id: 'playonline-disconnect', label: $t('menu.playonline-disconnect') || 'Disconnect', click() { win.webContents.send('menu.playonline-disconnect') } },
       ]
     },
     {
       label: $t('menu.game') || 'Game',
       submenu: [
-        { id: 'undo', label: $t('menu.undo') || 'Undo', accelerator: 'CommandOrControl+Z', click () { win.webContents.send('menu.undo') } },
+        { id: 'undo', label: $t('menu.undo') || 'Undo', accelerator: 'CommandOrControl+Z', click() { win.webContents.send('menu.undo') } },
         { type: 'separator' },
-        { id: 'leave-game', label: $t('menu.leave-game') || 'Leave Game', accelerator: 'CommandOrControl+W', click () { win.webContents.send('menu.leave-game') } },
+        { id: 'leave-game', label: $t('menu.leave-game') || 'Leave Game', accelerator: 'CommandOrControl+W', click() { win.webContents.send('menu.leave-game') } },
         { type: 'separator' },
-        { id: 'game-setup', label: $t('menu.show-game-setup') || 'Show game setup', click () { win.webContents.send('menu.game-setup') } },
+        { id: 'game-setup', label: $t('menu.show-game-setup') || 'Show game setup', click() { win.webContents.send('menu.game-setup') } },
         { type: 'separator' },
-        { id: 'zoom-in', label: $t('menu.zoom-in') || 'Zoom In', accelerator: 'numadd', registerAccelerator: false, click () { win.webContents.send('menu.zoom-in') } },
-        { id: 'zoom-out', label: $t('menu.zoom-out') || 'Zoom Out', accelerator: 'numsub', registerAccelerator: false, click () { win.webContents.send('menu.zoom-out') } },
-        { id: 'rotate', label: $t('menu.rotate') || 'Rotate', accelerator: 'r', registerAccelerator: false, click () { win.webContents.send('menu.rotate') } },
+        { id: 'zoom-in', label: $t('menu.zoom-in') || 'Zoom In', accelerator: 'numadd', registerAccelerator: false, click() { win.webContents.send('menu.zoom-in') } },
+        { id: 'zoom-out', label: $t('menu.zoom-out') || 'Zoom Out', accelerator: 'numsub', registerAccelerator: false, click() { win.webContents.send('menu.zoom-out') } },
+        { id: 'rotate', label: $t('menu.rotate') || 'Rotate', accelerator: 'r', registerAccelerator: false, click() { win.webContents.send('menu.rotate') } },
         { type: 'separator' },
-        { id: 'game-tiles', label: $t('menu.tiles') || 'Tiles', click () { win.webContents.send('menu.game-tiles') } },
-        { id: 'game-farm-hints', label: $t('menu.farm-hints') || 'Farm Hints', click () { win.webContents.send('menu.game-farm-hints') } },
-        { id: 'toggle-history', label: $t('menu.toggle-history') || 'Toggle History', accelerator: 'h', registerAccelerator: false, click () { win.webContents.send('menu.game-history') } }
+        { id: 'game-tiles', label: $t('menu.tiles') || 'Tiles', click() { win.webContents.send('menu.game-tiles') } },
+        { id: 'game-farm-hints', label: $t('menu.farm-hints') || 'Farm Hints', click() { win.webContents.send('menu.game-farm-hints') } },
+        { id: 'toggle-history', label: $t('menu.toggle-history') || 'Toggle History', accelerator: 'h', registerAccelerator: false, click() { win.webContents.send('menu.game-history') } }
       ]
     }, {
       label: $t('menu.help') || 'Help',
       submenu: [
-        { label: ($t('menu.rules') || 'Rules') + ' (WikiCarpedia)', click () { win.webContents.send('menu.rules') } },
-        { label: ($t('menu.report-bug') || 'Report a bug'), click () { win.webContents.send('menu.report-bug') } },
+        { label: ($t('menu.rules') || 'Rules') + ' (WikiCarpedia)', click() { win.webContents.send('menu.rules') } },
+        { label: ($t('menu.report-bug') || 'Report a bug'), click() { win.webContents.send('menu.report-bug') } },
         { type: 'separator' },
-        { label: $t('menu.about') || 'About', click () { win.webContents.send('menu.about') } }
+        { label: $t('menu.about') || 'About', click() { win.webContents.send('menu.about') } }
       ]
     }
   ]
@@ -98,15 +98,15 @@ async function createMenu (win, messages) {
       submenu: [
         { role: 'toggleDevTools', label: $t('dev.toggle-devtools') || 'Toggle DevTools' },
         { type: 'separator' },
-        { id: 'remote-engine', label: $t('dev.use-remote-engine') || 'Use Remote Engine', type: 'checkbox', checked: settings.enginePath === remoteEngineValue, click () { toggleRemoteEngine() } },
-        { id: 'local-play-online', label: $t('dev.use-local-play-online') || 'Use Local Play Online', type: 'checkbox', checked: settings.playOnlineUrl === 'localhost:8000/ws', click () { toggleLocalPlayOnline() } },
-        { id: 'dump-server', label: $t('dump-hosted-game-server-state') || 'Dump Hosted Game Server State', click () { win.webContents.send('menu.dump-server') } },
+        { id: 'remote-engine', label: $t('dev.use-remote-engine') || 'Use Remote Engine', type: 'checkbox', checked: settings.enginePath === remoteEngineValue, click() { toggleRemoteEngine() } },
+        { id: 'local-play-online', label: $t('dev.use-local-play-online') || 'Use Local Play Online', type: 'checkbox', checked: settings.playOnlineUrl === 'localhost:8000/ws', click() { toggleLocalPlayOnline() } },
+        { id: 'dump-server', label: $t('dump-hosted-game-server-state') || 'Dump Hosted Game Server State', click() { win.webContents.send('menu.dump-server') } },
         { type: 'separator' },
-        { id: 'test-runner', label: $t('dev.test-runner') || 'Test Runner', click () { win.webContents.send('menu.test-runner') } },
-        { id: 'save-for-test-runner', label: $t('dev.save-test-scenario') || 'Save Test Scenario', click () { win.webContents.send('menu.save-for-test-runner') } },
+        { id: 'test-runner', label: $t('dev.test-runner') || 'Test Runner', click() { win.webContents.send('menu.test-runner') } },
+        { id: 'save-for-test-runner', label: $t('dev.save-test-scenario') || 'Save Test Scenario', click() { win.webContents.send('menu.save-for-test-runner') } },
         { type: 'separator' },
-        { label: $t('dev.reload-add-ons') || 'Reload Add-ons', click () { win.webContents.send('menu.reload-addons') } },
-        { id: 'theme-inspector', label: $t('dev.theme-inspector') || 'Theme Inspector', click () { win.webContents.send('menu.theme-inspector') } }
+        { label: $t('dev.reload-add-ons') || 'Reload Add-ons', click() { win.webContents.send('menu.reload-addons') } },
+        { id: 'theme-inspector', label: $t('dev.theme-inspector') || 'Theme Inspector', click() { win.webContents.send('menu.theme-inspector') } }
       ]
     })
   }
@@ -141,11 +141,11 @@ export default function () {
   })
 
   return {
-    winCreated (win) {
+    winCreated(win) {
       _win = win
       createMenu(win, {})
     },
-    winClosed (win) {
+    winClosed(win) {
       _win = null
     }
   }

--- a/src/renderer/components/settings/AddonsSettings.vue
+++ b/src/renderer/components/settings/AddonsSettings.vue
@@ -2,6 +2,28 @@
   <div>
     <h3 class="mt-2 mb-4">{{ $t('settings.add-ons.title') }}</h3>
 
+    <h4>Add-ons manifest</h4>
+    <em>Leave empty to use the built-in manifest shipped with the app.</em>
+    <v-text-field
+      v-model.lazy="addonsManifestUrl"
+      class="manifest-url"
+      clearable
+      dense
+      hide-details
+      outlined
+      label="Manifest URL"
+      placeholder="Built-in default"
+      @click:clear="addonsManifestUrl = null"
+    />
+    <v-btn
+      class="mt-2"
+      small
+      text
+      @click="resetManifestUrl"
+    >
+      Use built-in default
+    </v-btn>
+
     <v-alert
       v-if="gameOpen"
       type="warning"
@@ -111,6 +133,14 @@ export default {
   },
 
   computed: {
+    addonsManifestUrl: {
+      get () { return this.$store.state.settings.addonsManifestUrl || '' },
+      set (val) {
+        const normalized = typeof val === 'string' ? val.trim() : ''
+        this.$store.dispatch('settings/update', { addonsManifestUrl: normalized || null })
+      }
+    },
+
     availableAddons() {
       return this.availableAddonsList.length>0
     },
@@ -127,6 +157,10 @@ export default {
   },
 
   methods: {
+    resetManifestUrl () {
+      this.addonsManifestUrl = null
+    },
+
     onDragover () {
       this.dragover = true
     },
@@ -159,8 +193,10 @@ export default {
     },
 
     async installAddon(addon) {
-      if (addon.installing) return
+      if (addon.installing)
+        return
       addon.installing = true
+      this.errors = []
       try {
         await this.$addons.installDownloadable(addon.key, addon.versions[0].version)
         addon.installed = true
@@ -175,7 +211,7 @@ export default {
     async installDownloadable (addon, version) {
       try {
         await this.$addons.installDownloadable(addon, version)
-	    this.loadAvailableAddons()
+	      this.loadAvailableAddons()
       } catch (e) {
         this.showAlert = true
         this.errors.push(e + '')
@@ -213,7 +249,7 @@ export default {
 
     getAddons () {
       // hide default
-      return this.$addons.addons.filter(addon => (!addon.hidden && addon.id != 'classic'))
+      return this.$addons.addons.filter(addon => !addon.hidden)
     },
     
     async loadAvailableAddons () {

--- a/src/renderer/layouts/default.vue
+++ b/src/renderer/layouts/default.vue
@@ -315,6 +315,11 @@ export default {
 
     await this.$store.dispatch('settings/registerChangeCallback', ['theme', onThemeChange])
     await this.$store.dispatch('settings/registerChangeCallback', ['userAddons', () => { this.loadAddons() }])
+    await this.$store.dispatch('settings/registerChangeCallback', ['addonsManifestUrl', async () => {
+      this.addonsUpdated = false
+      await this.loadAddons()
+      this.$addons.emit('change')
+    }])
     await this.$store.dispatch('settings/registerChangeCallback', ['enabledArtworks', (_, source) => {
       if (source === 'load') {
         // load only when triggered by manual user change, otherwise it's cause by addon install/uninstall and reloaed from her

--- a/src/renderer/pages/index.vue
+++ b/src/renderer/pages/index.vue
@@ -47,7 +47,9 @@
       <v-alert v-if="artworksLoaded && !hasClassicAddon" type="warning">
         {{ $t('settings.add-ons.artwork-not-found-internet-connection-is-needed') }}<br>
         {{ $t('settings.add-ons.please-check-connectivity-and-restart-app') }}<br>
-        <small>{{ $t('settings.add-ons.add-on-url') }}: <a :href="$addons.getDefaultArtworkUrl()" @click.prevent="openLink($addons.getDefaultArtworkUrl())">>{{ $addons.getDefaultArtworkUrl() }}</a></small>
+        <small v-if="classicAddonUrl">
+          {{ $t('settings.add-ons.add-on-url') }}: <a :href="classicAddonUrl" @click.prevent="openLink(classicAddonUrl)">{{ classicAddonUrl }}</a>
+        </small>
       </v-alert>
       <div v-if="download" class="download">
         <v-progress-linear
@@ -174,6 +176,7 @@ export default {
       // do not bind it to store
       recentSaves: [...this.$store.state.settings.recentSaves],
       updating: false,
+      classicAddonUrl: '',
       showRecentSetupMenu: false,
       menuX: null,
       menuY: null,
@@ -220,7 +223,15 @@ export default {
     },*/
     settingsLoaded () {
       this.recentSaves = [...this.$store.state.settings.recentSaves]
+    },
+
+    'settings.addonsManifestUrl' () {
+      this.refreshClassicAddonUrl()
     }
+  },
+
+  async mounted () {
+    await this.refreshClassicAddonUrl()
   },
 
   methods: {
@@ -279,7 +290,16 @@ export default {
     },
 
     afterAddonsReloaded () {
-      // DEL ?
+      this.refreshClassicAddonUrl()
+    },
+
+    async refreshClassicAddonUrl () {
+      try {
+        const urls = await this.$addons.getDefaultArtworkUrl()
+        this.classicAddonUrl = Array.isArray(urls) ? (urls.find(Boolean) || '') : (urls || '')
+      } catch {
+        this.classicAddonUrl = ''
+      }
     },
 
     showRecentSetup (e, idx) {

--- a/src/renderer/plugins/addons.js
+++ b/src/renderer/plugins/addons.js
@@ -1,5 +1,5 @@
 import os from 'os'
-import fs from 'fs-extra'
+import fs from 'fs'
 import path from 'path'
 import https from 'https'
 
@@ -18,67 +18,137 @@ import semver from 'semver'
 import { getAppVersion } from '@/utils/version'
 import { EventsBase } from '@/utils/events'
 
+const CLASSIC_ADDON_KEY = 'classic'
+const MEGA_PROVIDER = 'mega'
+const HTTPS_PROVIDER = 'https'
+
 class Addons extends EventsBase {
-  constructor (ctx) {
+  constructor(ctx) {
     super()
 
-    this.AUTO_DOWNLOADED = {
-      classic: {
-        url: [
-//          'https://jcloisterzone.com/packages/classic/classic-6-5.9.0.jca',
-          'https://mega.nz/file/HVJnFQaa#MIMfsuyvFopCeyWZZTcotXQcMpycHqA5UzHE4Fa1RFU'
-        ],
-        version: 6,
-        sha256: '26b1fc8edc37c9df162b6b5a74164c6ba09951e450df7b62f2568c2db03327b0'
-      }
-    }
-
+    this.AUTO_DOWNLOADED = null
     this.ctx = ctx
     this.addons = []
     this.downloadableInitialized = 0
+    this.downloadableManifestUrl = null
+    this.downloadableManifestError = null
     this.downloadable = []
   }
 
-  getDefaultArtworkUrl () {
-    return this.AUTO_DOWNLOADED?.classic?.url
+  async _ensureAutoDownloaded() {
+    if (this.AUTO_DOWNLOADED === null) {
+      this.AUTO_DOWNLOADED = await ipcRenderer.invoke('get-addon-defaults')
+    }
   }
-  
-  async getDownloadable() {
-    if (this.downloadableInitialized == 0 ) {
-      try {
-        let url = `https://github.com/fancarpedia/FanCloisterZone/releases/download/v6.0.0-all/addons.json`
-        const res = await fetch(url)
-        if (res.status === 200) {
-          const addons = await res.json()
-          const appVersion = await ipcRenderer.invoke('get-app-version')
-          const isDev = /-alpha|-beta|-rc/i.test(appVersion)
-          const appVer = semver.coerce(appVersion)
 
-          this.downloadable = addons.addons
+  async _getManifestUrl() {
+    await this._ensureAutoDownloaded()
+
+    const configuredUrl = this.ctx.store.state.settings.addonsManifestUrl
+    const normalizedUrl = typeof configuredUrl === 'string' ? configuredUrl.trim() : ''
+    return normalizedUrl || this.AUTO_DOWNLOADED?.addonsManifestUrl
+  }
+
+  _getLatestVersionDefinition(addonDefinition) {
+    if (!addonDefinition?.versions?.length) {
+      return null
+    }
+
+    return addonDefinition.versions.reduce((latestVersion, version) => (
+      !latestVersion || version.version > latestVersion.version ? version : latestVersion
+    ), null)
+  }
+
+  _reportManifestError(message) {
+    if (this.downloadableManifestError === message) {
+      return
+    }
+
+    this.downloadableManifestError = message
+    this.ctx.app.store.commit('errorMessage', {
+      title: 'Invalid add-ons manifest',
+      content: message
+    }, { root: true })
+  }
+
+  async getDefaultArtworkUrl() {
+    const downloadable = await this.getDownloadable()
+    const classic = downloadable.find(({ key }) => key === CLASSIC_ADDON_KEY)
+    const versionDefinition = this._getLatestVersionDefinition(classic)
+    if (versionDefinition) {
+      const urls = Array.isArray(versionDefinition.url) ? versionDefinition.url : [versionDefinition.url]
+      return urls.filter(Boolean)
+    }
+
+    return []
+  }
+
+  async getDownloadable() {
+    const manifestUrl = await this._getManifestUrl()
+    const needsRefresh = this.downloadableInitialized === 0 || this.downloadableManifestUrl !== manifestUrl
+    if (!needsRefresh) {
+      return this.downloadable
+    }
+
+    if (this.downloadableManifestUrl !== manifestUrl) {
+      this.downloadable = []
+      this.downloadableManifestUrl = manifestUrl
+      this.downloadableManifestError = null
+    }
+
+    if (!manifestUrl) {
+      return this.downloadable
+    }
+
+    try {
+      const res = await fetch(manifestUrl)
+      if (res.status === 200) {
+        const addons = await res.json()
+        const appVersion = await ipcRenderer.invoke('get-app-version')
+        const isDev = /-alpha|-beta|-rc/i.test(appVersion)
+        const appVer = semver.coerce(appVersion)
+
+        this.downloadable = (addons.addons || [])
           .map(addon => {
-            const compatibleVersions = addon.versions.filter(v => {
-              const fromVersion = isDev ? (v.devFromVersion ?? (v.fromVersion ?? null)) : (v.fromVersion ?? null)
+            const addonVersions = Array.isArray(addon.versions) ? addon.versions : []
+            const compatibleVersions = addonVersions.filter(version => {
+              const fromVersion = isDev ? (version.devFromVersion ?? (version.fromVersion ?? null)) : (version.fromVersion ?? null)
               const fromOk = fromVersion ? semver.gte(appVer, semver.coerce(fromVersion)) : true
-              const toVersion = isDev ? (v.devToVersion ?? (v.toVersion ?? null)) : (v.toVersion ?? null)
+              const toVersion = isDev ? (version.devToVersion ?? (version.toVersion ?? null)) : (version.toVersion ?? null)
               const toOk = toVersion ? semver.lt(appVer, semver.coerce(toVersion)) : true // exclusive upper bound
               return fromOk && toOk
             })
             if (compatibleVersions.length > 0) {
-              return { ...addon, versions: compatibleVersions }
+              return { ...addon, autoUpdate: addon.autoUpdate !== false, versions: compatibleVersions }
             }
             return null
           })
-          .filter(a => a !== null)
+          .filter(addon => addon !== null)
+
+        const classicAddon = this.downloadable.find(({ key }) => key === CLASSIC_ADDON_KEY)
+        const classicVersionDefinition = this._getLatestVersionDefinition(classicAddon)
+        console.debug('Classic add-on version definition from manifest:', classicVersionDefinition)
+        if (!classicVersionDefinition) {
+          this._reportManifestError('Add-ons manifest must contain a compatible classic add-on.')
+          this.downloadableInitialized = 1
+          return this.downloadable
         }
+
+        if (!classicVersionDefinition.sha256) {
+          this._reportManifestError('Classic add-on entry in manifest must include sha256.')
+          this.downloadableInitialized = 1
+          return this.downloadable
+        }
+
         this.downloadableInitialized = 1
-      } catch(err) {
-        // No internet?
       }
+    } catch (err) {
+      // No internet?
     }
     return this.downloadable
   }
 
-  async loadAddons () {
+  async loadAddons() {
     const { settings } = this.ctx.store.state
     const userDataPath = window.process.argv.find(arg => arg.startsWith('--user-data=')).replace('--user-data=', '')
     const installedAddons = []
@@ -99,7 +169,7 @@ class Addons extends EventsBase {
           const fullPath = path.join(folder, id)
           const addon = await this._readAddon(id, fullPath)
           if (addon) {
-            addon.removable = removable && id !== 'classic'
+            addon.removable = removable && id !== CLASSIC_ADDON_KEY
             addon.hidden = hidden
             installedAddons.push(addon)
             installedAddonsIds.add(id)
@@ -140,25 +210,25 @@ class Addons extends EventsBase {
       }
     }
 
-    this.ctx.app.store.commit('hasClassicAddon', !!installedAddons.find(a => a.id === 'classic' && !a.error))
+    this.ctx.app.store.commit('hasClassicAddon', !!installedAddons.find(a => a.id === CLASSIC_ADDON_KEY && !a.error))
 
     this.addons = sortBy(installedAddons, ['removable', 'id'])
     this.ctx.app.store.commit('addonsLoaded')
   }
 
-  async mkAddonsFolder () {
+  async mkAddonsFolder() {
     const userDataPath = window.process.argv.find(arg => arg.startsWith('--user-data=')).replace('--user-data=', '')
     const addonsFolder = path.join(userDataPath, 'addons')
     await fs.promises.mkdir(addonsFolder, { recursive: true })
     return addonsFolder
   }
-  
+
   async installDownloadable(addonKey, version) {
     const downloadable = await this.getDownloadable()
     if (!downloadable) {
       throw new Error($nuxt.$t('settings.add-ons.add-ons-definition-not-available'))
     }
-    
+
     const addonDefinition = downloadable.find(a => a.key === addonKey)
     if (!addonDefinition) {
       throw new Error($nuxt.$t('settings.add-ons.download-definition-not-found'))
@@ -171,6 +241,11 @@ class Addons extends EventsBase {
 
     const downloadedPath = path.join(os.tmpdir(), `${addonKey}-v${versionDefinition.version}.jca`)
 
+    const downloadUrl = await this.resolveDownloadUrl(versionDefinition.url)
+    if (!downloadUrl) {
+      throw new Error($nuxt.$t('settings.add-ons.download-definition-not-found'))
+    }
+
     const installed = this.addons.find(a => a.id === addonKey)
     if (installed) {
       const installedVersion = installed.json.version
@@ -179,37 +254,13 @@ class Addons extends EventsBase {
       if (installedVersion >= requestedVersion) {
         return
       }
-      
+
       console.log(`Reinstalling ${addonKey}: v${installedVersion} → v${requestedVersion}`)
       await this.uninstall(installed)
     }
 
     // Download provider
-    let downloadPromise
-    if (versionDefinition.provider === 'mega') {
-      const file = File.fromURL(versionDefinition.url)
-      downloadPromise = new Promise((resolve, reject) => {
-        file
-        .download()
-        .pipe(fs.createWriteStream(downloadedPath))
-        .on('error', reject)
-        .on('finish', resolve)
-      })
-    } else if (versionDefinition.provider === 'https') {
-      const res = await fetch(versionDefinition.url)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-
-      downloadPromise = new Promise((resolve, reject) => {
-        const fileStream = fs.createWriteStream(downloadedPath)
-        res.body.pipe(fileStream)
-        fileStream.on('finish', resolve)
-        fileStream.on('error', reject)
-      })
-    } else {
-      throw new Error(`Unknown provider: ${versionDefinition.provider}`)
-    }
-
-    await downloadPromise
+    await this.downloadAddonFile(versionDefinition.provider, downloadUrl, downloadedPath)
 
     // --- SHA-256 verification ---
     if (versionDefinition.sha256) {
@@ -223,43 +274,100 @@ class Addons extends EventsBase {
     await this.install(downloadedPath)
   }
 
-  downloadFromMega (link, zipName, file, resolve, reject) {
+  async resolveDownloadUrl(urls) {
+    if (!Array.isArray(urls)) {
+      return urls || null
+    }
+
+    for (const currentUrl of urls.filter(Boolean)) {
+      try {
+        if (await this.urlExists(currentUrl)) {
+          return currentUrl
+        }
+      } catch (error) {
+        continue
+      }
+    }
+
+    return null
+  }
+
+  async downloadAddonFile(provider, link, downloadFileName) {
+    try {
+      await fs.promises.unlink(downloadFileName)
+    } catch {
+      // file does not exist, no need to delete
+    }
+
+    let fileStream
+    try {
+      fileStream = fs.createWriteStream(downloadFileName)
+    } catch (err) {
+      console.warn(`Error creating write stream for ${downloadFileName}:`, err)
+      throw new Error($nuxt.$t('settings.add-ons.download-file-write-error'))
+    }
+
+    try {
+      await new Promise((resolve, reject) => {
+        switch (provider) {
+          case MEGA_PROVIDER:
+            this.downloadFromMega(link, fileStream, downloadFileName, resolve, reject)
+            break;
+          case HTTPS_PROVIDER:
+            this.downloadFileFromUrl(link, fileStream, downloadFileName, resolve, reject)
+            break;
+          default:
+            throw new Error(`Unknown provider: ${provider}`)
+        }
+      });
+    } catch (e) {
+      console.error(`Error downloading add-on file (${downloadFileName}) with provider ${provider}:`, e)
+      await fs.promises
+        .unlink(downloadFileName)
+        .catch(err => {
+          console.warn(`Error deleting incomplete add-on file (${downloadFileName}):`, err)
+        })
+      throw e
+    }
+  }
+
+  downloadFromMega(link, fileStream, downloadFileName, resolve, reject) {
     try {
       const megaFile = File.fromURL(link)
       let downloadedBytes = 0
-    
+
       // Set total size if available
       megaFile.loadAttributes().then(() => {
         this.ctx.app.store.commit('downloadSize', megaFile.size)
       }).catch(err => console.warn('Could not load Mega file size:', err))
-    
+
       megaFile
         .download()
         .on('data', chunk => {
           downloadedBytes += chunk.length
           this.ctx.app.store.commit('downloadProgress', downloadedBytes)
         })
-        .pipe(file)
+        .pipe(fileStream)
         .on('error', function (err) {
           console.error(err)
-          fs.unlink(zipName, unlinkErr => {
+          fs.unlink(downloadFileName, unlinkErr => {
             console.warn(unlinkErr)
           })
           reject(err.message)
         })
         .on('finish', function () {
-          file.close(resolve)
+          fileStream.close(resolve)
         })
     } catch (error) {
       console.error(error)
-      fs.unlink(zipName, unlinkErr => {
+      fs.unlink(downloadFileName, unlinkErr => {
         console.warn(unlinkErr)
       })
       reject(error.message)
     }
   }
 
-  async install (filePath) {
+  async install(filePath) {
     const addonsFolder = await this.mkAddonsFolder()
 
     const tmpFolder = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'addon-'))
@@ -297,7 +405,7 @@ class Addons extends EventsBase {
     })
   }
 
-  async uninstall (addon) {
+  async uninstall(addon) {
     await fs.promises.rmdir(addon.folder, { recursive: true })
 
     if (addon.artworks?.length) { // may be undefined for invalid artwork
@@ -310,25 +418,25 @@ class Addons extends EventsBase {
       resolve()
     })
     this.addons = this.addons.filter(a => a.id !== addon.id)
-    
+
   }
 
-  async urlExists (url) {
+  async urlExists(url) {
     // Check if it's a Mega.nz link
     if (url.includes('mega.nz')) {
       return await this.checkMegaFile(url)
     }
-  
+
     try {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), 5000) // 5 second timeout
-    
-      const response = await fetch(url, { 
+
+      const response = await fetch(url, {
         method: 'HEAD',
         signal: controller.signal
       })
       clearTimeout(timeoutId)
-    
+
       return response.ok
     } catch (error) {
       console.warn(`Fetch failed: ${error.message}`)
@@ -336,32 +444,46 @@ class Addons extends EventsBase {
     }
   }
 
-  async checkMegaFile (url) {
+  async checkMegaFile(url) {
     try {
       const file = File.fromURL(url)
       await file.loadAttributes()
       return true
     } catch (error) {
+      console.warn(`Error checking URL ${url}: ${error.message}`)
       return false
     }
   }
 
-  async updateOutdatedClassic (installedAddons) {
-    const classicArtwork = installedAddons.find(({ id }) => id === 'classic')
+  async updateOutdatedClassic(installedAddons) {
+    const downloadable = await this.getDownloadable()
+    const classicDownloadable = downloadable.find(({ key }) => key === CLASSIC_ADDON_KEY)
+    const classicVersionDefinition = this._getLatestVersionDefinition(classicDownloadable)
+
+    if (!classicVersionDefinition) {
+      return
+    }
+
+    const classicAutoUpdate = classicDownloadable.autoUpdate !== false
+
+    const classicArtwork = installedAddons.find(({ id }) => id === CLASSIC_ADDON_KEY)
     if (classicArtwork) {
       if (!classicArtwork.outdated && !classicArtwork.error) {
+        return
+      }
+      if (!classicAutoUpdate) {
         return
       }
       installedAddons.splice(installedAddons.indexOf(classicArtwork), 1)
     }
 
     const addonsFolder = await this.mkAddonsFolder()
-    const fullPath = path.join(addonsFolder, 'classic')
+    const fullPath = path.join(addonsFolder, CLASSIC_ADDON_KEY)
 
     try {
       const stat = await fs.promises.stat(fullPath)
       if (stat.isDirectory() && !classicArtwork?.outdated && !classicArtwork?.error) {
-        const artwork = await this._readAddon('classic', fullPath)
+        const artwork = await this._readAddon(CLASSIC_ADDON_KEY, fullPath)
         installedAddons.unshift(artwork)
         return
       }
@@ -369,83 +491,51 @@ class Addons extends EventsBase {
       // fullPath doesn't exist yet, proceed with download
     }
 
-    const links = this.getDefaultArtworkUrl()
-    let link = null
+    const links = Array.isArray(classicVersionDefinition.url)
+      ? classicVersionDefinition.url
+      : [classicVersionDefinition.url]
+    const downloadUrl = await this.resolveDownloadUrl(links)
 
-    for (let i = 0; i < links.length; i++) {
-      try {
-        const exists = await this.urlExists(links[i])
-        if (exists) {
-          link = links[i]
-          break
-        }
-      } catch (error) {
-        continue
-      }
+    if (!downloadUrl) {
+      this.ctx.app.store.commit('download', null)
+      return
     }
+
+    console.log('Updating classic artwork, download link: ' + downloadUrl)
+    console.log('expected sha256: ' + classicVersionDefinition.sha256)
+    console.log('Downloading to ' + fullPath)
 
     this.ctx.app.store.commit('download', {
       name: 'classic.jca',
       description: 'Downloading classic artwork',
       progress: null,
       size: null,
-      link
+      link: downloadUrl
     })
 
-    const zipName = path.join(addonsFolder, 'classic.jca')
-    try {
-      if ((await fs.promises.stat(zipName)).isFile()) {
-        await fs.promises.unlink(zipName)
-      }
-    } catch {
-      // ignore
-    }
-    const file = fs.createWriteStream(zipName)
-    try {
-      await new Promise((resolve, reject) => {
-        if (link.includes('mega.nz')) {
-          // Download from Mega.nz
-          this.downloadFromMega(link, zipName, file, resolve, reject)
-        } else {
-          // Download via HTTPS
-          let downloadedBytes = 0
-          const agent = new https.Agent({ rejectUnauthorized: false })
-          https.get(link, { agent }, response => {
-            const total = parseInt(response.headers['content-length'])
-            this.ctx.app.store.commit('downloadSize', total)
-            response.on('data', chunk => {
-              downloadedBytes += chunk.length
-              this.ctx.app.store.commit('downloadProgress', downloadedBytes)
-            })
-            response.pipe(file)
-            file.on('finish', function () {
-              file.close(resolve)
-            })
-          }).on('error', function (err) {
-            console.error(err)
-            fs.unlink(zipName, unlinkErr => {
-              console.warn(unlinkErr)
-            })
-            reject(err.message)
-          })
-        }
-      })
-    } catch (e) {
+    const downloadedPath = path.join(addonsFolder, 'classic.jca')
+    const downloadProvider = classicVersionDefinition.provider || HTTPS_PROVIDER
+    await this.downloadAddonFile(downloadProvider, downloadUrl, downloadedPath)
+
+    const expectedChecksum = classicVersionDefinition.sha256
+    if (!expectedChecksum) {
+      this._reportManifestError('Classic add-on entry in manifest must include sha256.')
       this.ctx.app.store.commit('download', null)
+      await fs.promises.unlink(downloadedPath)
       return
     }
 
-    const checksum = sha256File(zipName)
-    if (checksum !== this.AUTO_DOWNLOADED.classic.sha256) {
+    const checksum = sha256File(downloadedPath)
+    if (checksum !== expectedChecksum) {
       console.log('classic.jca checksum mismatch ' + checksum)
       this.ctx.app.store.commit('download', {
         name: 'classic.jca',
         description: 'Error: Downloaded file has invalid checksum',
         progress: 0,
-        size: this.AUTO_DOWNLOADED.classic.size,
-        link
+        size: null,
+        link: downloadUrl
       })
-      await fs.promises.unlink(zipName)
+      await fs.promises.unlink(downloadedPath)
       return
     }
 
@@ -454,57 +544,128 @@ class Addons extends EventsBase {
       console.log('Removing outdated artwork ' + classicArtwork.folder)
       await fs.promises.rmdir(classicArtwork.folder, { recursive: true })
     }
-    await fs.createReadStream(zipName)
+    await fs.createReadStream(downloadedPath)
       .pipe(unzipper.Extract({ path: addonsFolder }))
       .promise()
-    await fs.promises.unlink(zipName)
+    await fs.promises.unlink(downloadedPath)
     this.ctx.app.store.commit('download', null)
 
-    const artwork = await this._readAddon('classic', fullPath)
+    const artwork = await this._readAddon(CLASSIC_ADDON_KEY, fullPath)
     installedAddons.unshift(artwork)
   }
 
-  async updateOutdatedAddons () {
+  downloadFileFromUrl(link, downloadStream, downloadFileName, resolve, reject, redirectCount = 0) {
+    let downloadedBytes = 0
+    let completed = false
+
+    const finishWithError = (error) => {
+      if (completed) {
+        return
+      }
+      completed = true
+      console.error(error)
+      fs.unlink(downloadFileName, unlinkErr => {
+        console.warn(unlinkErr)
+      })
+      reject(error.message)
+    }
+
+    const agent = new https.Agent({ rejectUnauthorized: false })
+
+    https.get(link, { agent }, response => {
+      const statusCode = response.statusCode || 0
+      const location = response.headers.location
+
+      if (statusCode >= 300 && statusCode < 400 && location) {
+        if (redirectCount >= 10) {
+          response.resume()
+          finishWithError(new Error(`Too many redirects while downloading ${downloadFileName}`))
+          return
+        }
+
+        const nextLink = new URL(location, link).toString()
+        console.log(`Redirecting download ${statusCode} -> ${nextLink}`)
+        response.resume()
+        this.downloadFileFromUrl(nextLink, downloadStream, downloadFileName, resolve, reject, redirectCount + 1)
+        return
+      }
+
+      const totalHeader = response.headers['content-length']
+      const total = totalHeader ? parseInt(totalHeader, 10) : NaN
+      const hasKnownSize = Number.isFinite(total) && total > 0
+
+      this.ctx.app.store.commit('downloadSize', hasKnownSize ? total : null)
+      console.log(hasKnownSize ? `Total size: ${total} bytes` : `Total size unavailable for ${link}`)
+
+      response.on('data', chunk => {
+        downloadedBytes += chunk.length
+        if (hasKnownSize) {
+          console.log(`Downloaded ${downloadedBytes} of ${total} bytes`)
+        }
+        this.ctx.app.store.commit('downloadProgress', downloadedBytes)
+      })
+
+      const responseErrorHandler = err => finishWithError(err)
+      response.on('error', responseErrorHandler)
+      downloadStream.on('error', responseErrorHandler)
+
+      response.pipe(downloadStream)
+      downloadStream.on('finish', function () {
+        if (completed) {
+          return
+        }
+        completed = true
+        console.log('Download finished, file saved to ' + downloadFileName)
+        downloadStream.close(resolve)
+      })
+    }).on('error', function (err) {
+      finishWithError(err)
+    })
+  }
+
+  async updateOutdatedAddons() {
     const installedAddons = this.addons
     const downloadable = await this.getDownloadable()
 
     let updated = false
 
     for (const installed of installedAddons) {
-        const addon = installed.id
-        const available = downloadable.find(({ key }) => key === addon)
-        
-        if (!available) continue
+      const addon = installed.id
+      const available = downloadable.find(({ key }) => key === addon)
 
-        // get the highest available version
-        const newest = available.versions.reduce((max, v) => 
-            v.version > max.version ? v : max
-        )
-        if (newest.version > installed.json.version) {
-            console.log(`Updating ${addon}: v${installed.json.version} → v${newest.version}`)
+      if (!available) continue
 
-            try {
-              updated = true
-              await this.uninstall(installed)
-              await this.installDownloadable(addon, newest.version)
-            } catch (err) {
-              console.error(`Failed updating ${addon}`, err)
-            }
+      if (available.autoUpdate === false) continue
+
+      // get the highest available version
+      const newest = available.versions.reduce((max, v) =>
+        v.version > max.version ? v : max
+      )
+      if (newest.version > installed.json.version) {
+        console.log(`Updating ${addon}: v${installed.json.version} → v${newest.version}`)
+
+        try {
+          updated = true
+          await this.uninstall(installed)
+          await this.installDownloadable(addon, newest.version)
+        } catch (err) {
+          console.error(`Failed updating ${addon}`, err)
         }
-        if (updated) {
-          await this.loadAddons()
-          if (this.$theme) {
-            await this.$theme.loadArtworks()
-          }
-          if (this.$tiles) {
-            await this.$tiles.loadExpansions()
-          }
+      }
+      if (updated) {
+        await this.loadAddons()
+        if (this.$theme) {
+          await this.$theme.loadArtworks()
         }
-    }    
-    
+        if (this.$tiles) {
+          await this.$tiles.loadExpansions()
+        }
+      }
+    }
+
   }
 
-  findMissingAddons (required) {
+  findMissingAddons(required) {
     const installed = this.addons.reduce((acc, addon) => {
       acc[addon.id] = addon.json.version
       return acc
@@ -520,7 +681,7 @@ class Addons extends EventsBase {
     return missing
   }
 
-  async _readAddon (id, fullPath) {
+  async _readAddon(id, fullPath) {
     const stats = await fs.promises.stat(fullPath)
     if (stats.isDirectory()) {
       const jsonPath = path.join(fullPath, 'jcz-addon.json')
@@ -533,12 +694,13 @@ class Addons extends EventsBase {
       }
       try {
         json.id = id
+        const remoteDownloadable = (await this.getDownloadable()).find(({ key }) => key === id)
         const addon = {
           id,
           title: json.title,
           folder: fullPath,
           json,
-          remote: this.AUTO_DOWNLOADED[id] || null
+          remote: this._getLatestVersionDefinition(remoteDownloadable)
         }
         if (!isNumber(addon.json.version)) {
           addon.error = 'Invalid add-on. Expecting number as version found string.'
@@ -567,7 +729,7 @@ class Addons extends EventsBase {
     return null
   }
 
-  async _readArtwork (id, fullPath) {
+  async _readArtwork(id, fullPath) {
     const stats = await fs.promises.stat(fullPath)
     if (stats.isDirectory()) {
       const jsonPath = path.join(fullPath, 'artwork.json')
@@ -601,7 +763,7 @@ class Addons extends EventsBase {
 export default (ctx, inject) => {
   let instance = null
   const prop = {
-    get () {
+    get() {
       if (instance === null) {
         instance = new Addons(ctx)
       }

--- a/src/renderer/store/settings.js
+++ b/src/renderer/store/settings.js
@@ -15,6 +15,7 @@ const RECENT_SETUP_FILE_COUNT = 9
 export const state = () => ({
   file: null,
   userAddons: [],
+  addonsManifestUrl: null,
   enabledArtworks: ['classic/classic'],
   lastGameSetup: null,
   mySetups: [],


### PR DESCRIPTION
## What changed

- The add-ons manifest is no longer discovered from one fixed place only.
- Manifest sources setting added
- The app falls back to a built-in manifest URL when the setting is empty.
- The classic artwork add-on is treated as a managed add-on so that it can be validated and updated automatically.
- Changing add-on settings or installing/removing an add-on triggers a refresh.

Example of the new manifest, including classic addon:
https://github.com/DarthKurt/jcloisterzone-assets/releases/download/v0.2.0/addons.json
